### PR TITLE
chore: test for async data func

### DIFF
--- a/types/react-mentions/react-mentions-tests.tsx
+++ b/types/react-mentions/react-mentions-tests.tsx
@@ -84,6 +84,27 @@ export const TestMultipleTrigger: React.SFC<TestProps> = props => {
     );
 };
 
+export const TestAsyncDataFunc: React.FunctionComponent<TestProps> = props => {
+    return (
+        <MentionsInput value={props.value} onChange={props.onChange} placeholder={"Mention people using '@'"}>
+            {/* Using async function syntax: */}
+            <Mention
+                trigger={props.regex}
+                markup={`@[${PLACEHOLDERS.display}](__type__:${PLACEHOLDERS.id})`}
+                data={async search => [{ id: search, display: search }]}
+                onAdd={props.onAdd}
+            />
+            {/* Using explicit Promise syntax: */}
+            <Mention
+                trigger={props.regex}
+                markup={`@[${PLACEHOLDERS.display}](__type__:${PLACEHOLDERS.id})`}
+                data={search => Promise.resolve([{ id: search, display: search }])}
+                onAdd={props.onAdd}
+            />
+        </MentionsInput>
+    );
+};
+
 /**
  * Utils
  */


### PR DESCRIPTION
@boroth regarding your pr at DefinitelyTyped/DefinitelyTyped#55831 I am proposing a test you can include for your type change. Now that I look at it and your type, this could also use a test for returning `Promise<void>` too, if you want to add that one.

Once you have this, you should be able to run `npm test react-mentions` from the root of the DefinitelyTyped repo to test the types.

NOTE: I didn't actually test this with the js version of the package, but I presume you have (and it looks consistent with looks consistent with https://github.com/signavio/react-mentions/blob/master/demo/src/examples/AsyncGithubUserMentions.js#L10)!